### PR TITLE
Reformatted to improve performance

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -8,10 +8,20 @@ import Footer from './Components/Footer';
 import Home from './Pages/Home';
 import Page from './Pages/Page';
 import PostPage from './Pages/PostPage';
+import DataActions from './flux/actions/DataActions';
+import DataStore from './flux/stores/DataStore';
 import './styles/App.css';
 
 
 class App extends Component {
+
+  componentDidMount(){
+    DataActions.getPages(()=>{
+      this.setState({
+          data: DataStore.getAll()
+      });
+    });
+  }
 
   render() {
     return (

--- a/src/Components/NavigationBar.js
+++ b/src/Components/NavigationBar.js
@@ -3,8 +3,7 @@ import {Navbar,
         Nav,
         NavItem,
         FormGroup,
-        FormControl,
-        Button
+        FormControl
         } from 'react-bootstrap';
 import {NavLink} from 'react-router-dom';
 import {LinkContainer} from 'react-router-bootstrap';

--- a/src/Components/Post.js
+++ b/src/Components/Post.js
@@ -1,38 +1,34 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import DataActions from '../flux/actions/DataActions.js';
 import DataStore from '../flux/stores/DataStore.js';
+import connectToStores from 'alt-utils/lib/connectToStores';
 
-export default class Post extends Component{
-
-    state = {
-        data: {}
-    };
+class Post extends Component{
 
     static propTypes = {
         id: PropTypes.number.isRequired
     }
 
-    componentDidMount(){
-        this.getNewPost();
+    static getStores(){
+        return [DataStore];
     }
 
-    getNewPost(){
-        DataActions.getPages(()=>{
-            this.setState({
-                data: DataStore.getPostById(this.props.id)
-            });
-        });
+    static getPropsFromStores(){
+        return DataStore.getState();
     }
 
     render(){
+        let post = DataStore.getPostById(this.props.id);
+
         return(
             <div className="content-container">
-                <h1>{this.state.data.title ? this.state.data.title.rendered : ""}</h1>
+                <h1>{post.title ? post.title.rendered : ""}</h1>
                     <div 
                     className="content-field"
-                    dangerouslySetInnerHTML={{__html: this.state.data.content ? this.state.data.content.rendered :""}}></div>
+                    dangerouslySetInnerHTML={{__html: post.content ? post.content.rendered :""}}></div>
             </div>    
         );
     }
 }
+
+export default connectToStores(Post);

--- a/src/Components/PostOnHome.js
+++ b/src/Components/PostOnHome.js
@@ -4,11 +4,13 @@ import {Col} from 'react-bootstrap';
 import {LinkContainer} from 'react-router-bootstrap';
 
 function removeLink(excerpt){ //remove here so it won't be visible when inspected
-
+    let retStr = excerpt;
     let startIndex = excerpt.indexOf('<p class="link-more"');
-    let endIndex = excerpt.indexOf('</p>',startIndex)+4;
-
-    let retStr = excerpt.slice(0,startIndex)+excerpt.slice(endIndex+1,excerpt.length);
+    if(startIndex !== -1){
+        let endIndex = excerpt.indexOf('</p>',startIndex)+4;
+        retStr = excerpt.slice(0,startIndex)+excerpt.slice(endIndex+1,excerpt.length);
+    }
+    
 
     return retStr;
 }

--- a/src/Pages/Page.js
+++ b/src/Pages/Page.js
@@ -1,11 +1,10 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import DataActions from '../flux/actions/DataActions.js';
 import DataStore from '../flux/stores/DataStore.js';
 import Banner from '../Components/Banner';
+import connectToStores from 'alt-utils/lib/connectToStores';
 
-
-export default class Page extends Component{
+class Page extends Component{
 
     state = {
         data: {}
@@ -15,23 +14,43 @@ export default class Page extends Component{
         slug: PropTypes.string.isRequired
     }
 
+    static getStores(){
+        return [DataStore];
+    }
+
+    static getPropsFromStores(){
+        return DataStore.getState();
+    }
+
     componentDidMount(){
-        this.getNewPage();
+        
+    }
+
+    reconcileSlug(){
+       if(this.props.slug!==this.state.data.slug){
+           return this.getNewPage();
+       } 
     }
 
     getNewPage(){
-        DataActions.getPages(()=>{
-            this.setState({
-                data: DataStore.getPageBySlug(this.props.slug)
-            });
-        });
+        let retObj = {
+            header: DataStore.getPageBySlug(this.props.slug).title
+                ?
+                DataStore.getPageBySlug(this.props.slug).title.rendered
+                :
+                "",
+            content: DataStore.getPageBySlug(this.props.slug).content
+                ?
+                DataStore.getPageBySlug(this.props.slug).content.rendered
+                :
+                ""
+        };
+        return retObj;
     }
 
     render(){
         window.scrollTo(0,0);
-        if(this.props.slug !== this.state.data.slug){
-            this.getNewPage();
-        }
+        let {header,content} = this.reconcileSlug();
         
         return(
             <div>
@@ -39,12 +58,14 @@ export default class Page extends Component{
                     <Banner />
                 </div>
                 <div className="content-container">
-                    <h1>{this.state.data.title ? this.state.data.title.rendered : ""}</h1>
+                    <h1>{header}</h1>
                     <div 
                     className="content-field"
-                    dangerouslySetInnerHTML={{__html: this.state.data.content ? this.state.data.content.rendered :""}}></div>
+                    dangerouslySetInnerHTML={{__html:content}}></div>
                 </div>
             </div>
         );
     }
 }
+
+export default connectToStores(Page);

--- a/src/flux/actions/DataActions.js
+++ b/src/flux/actions/DataActions.js
@@ -9,6 +9,7 @@ class DataActions {
 
         this.pagesEndPoint = `${appUrl}/wp-json/wp/v2/pages`; //Endpoint for Wordpress pages
         this.postsEndPoint = `${appUrl}/wp-json/wp/v2/posts/?per_page=90`; //Endpoint for Wordpress posts
+        //limiting to 120 posts.  Anything else can be found through the archives links
         this.postsCatEndPoint = `${appUrl}/wp-json/wp/v2/posts?categories=`; //Endpoint for Wordpress posts filtered for a specific category
     }
 
@@ -24,30 +25,10 @@ class DataActions {
         });
     }
 
-    getPages(cb,cat=""){ //if category included, it filters posts
-        if(cat){
-            this.api(this.pagesEndPoint)
-                .then( (response) => {
-                    this.getPostsByCat(response,cat,cb)
-                });
-        }
-        else{
-            this.api(this.pagesEndPoint)
-                .then( (response) => {
-                    this.getPosts(response,cb)
-                });
-        }
-        return true;
-    }
-
-    getPostsByCat(pages,cat,cb){
-        this.api(this.postsCatEndPoint+cat)
-            .then( (response) =>{
-                const posts = response;
-                const payload = {pages,posts};
-
-                this.getSuccess(payload);
-                cb(payload);
+    getPages(cb){ //if category included, it filters posts
+        this.api(this.pagesEndPoint)
+            .then( (response) => {
+                this.getPosts(response,cb)
             });
         return true;
     }

--- a/src/flux/stores/DataStore.js
+++ b/src/flux/stores/DataStore.js
@@ -3,11 +3,14 @@ import DataActions from '../actions/DataActions.js';
 
 class DataStore{
     constructor() {
-        this.data = {};
+        this.data={
+            posts: {},
+            pages: {}
+        };
 
         this.bindListeners({
             
-            handleSuccess: DataActions.GET_SUCCESS
+            handleSuccess: DataActions.getSuccess
         });
 
         this.exportPublicMethods({
@@ -15,7 +18,8 @@ class DataStore{
             getAllPages: this.getAllPages,
             getAllPosts: this.getAllPosts,
             getPageBySlug: this.getPageBySlug,
-            getPostById: this.getPostById
+            getPostById: this.getPostById,
+            getPostByCat: this.getPostByCat
         });
     }
 
@@ -47,6 +51,19 @@ class DataStore{
         return posts[Object.keys(posts).find( (post,i) => {
             return posts[post].id === Id;
         })] || {}
+    }
+
+    getPostByCat(cat){
+        const posts = this.getState().data.posts;
+        return posts.filter((post)=>{
+            let ret=false;
+            for(let val=0;val<post.categories.length;val++){
+                if(cat === post.categories[val]){
+                    ret = true;
+                }
+            }
+            return ret;
+        });
     }
 }
 


### PR DESCRIPTION
Since the data (pages and posts) store really only needs to be initiated once for this blog (it's fairly small and we can setup the archive pages to be fine with limiting to 90 posts returned max), it is now implemented in App.js.  Also removed the multiple calls to the API in favor of the one - now we just reference the store when switching to different views/routes.